### PR TITLE
Fix rerendering bug causing memory leak

### DIFF
--- a/src/components/Map.tsx
+++ b/src/components/Map.tsx
@@ -1,7 +1,6 @@
 "use client";
-
+import React, { useState, useRef, useEffect, useCallback } from 'react';
 import Image from 'next/image';
-import { useState, useRef, useEffect } from 'react';
 import Link from 'next/link';
 
 interface Marker {
@@ -13,26 +12,38 @@ interface Marker {
   link: string;
 }
 
+interface MarkerProps {
+  marker: Marker;
+}
+
+const MemorizedMarker: React.FC<MarkerProps> = React.memo(({ marker }) => (
+  <Link
+    href={marker.link}
+    className="absolute flex items-center justify-center text-white font-bold rounded-xl bg-[#ec9bfc] border-[5px] border-[#e466fc] transform -translate-x-1/2 -translate-y-1/2 w-10 h-10"
+    style={{ left: `${marker.x}px`, top: `${marker.y}px` }}
+  >
+    {marker.id}
+  </Link>
+));
+MemorizedMarker.displayName = 'MemorizedMarker';
+
 const Map: React.FC = () => {
   const containerRef = useRef<HTMLDivElement | null>(null);
   const imageRef = useRef<HTMLImageElement | null>(null);
-
   const [markers, setMarkers] = useState<Marker[]>([
     { id: 1, top: '30%', left: '20%', x: 0, y: 0, link: '/home/marker1' },
     { id: 2, top: '50%', left: '40%', x: 0, y: 0, link: '/home/marker2' },
     { id: 3, top: '50%', left: '60%', x: 0, y: 0, link: '/home/marker3' },
   ]);
 
-  const positionMarkers = () => {
+  const positionMarkers = useCallback(() => {
     const container = containerRef.current;
     const image = imageRef.current;
-
     if (!container || !image) return;
 
     const containerRect = container.getBoundingClientRect();
     const imageAspectRatio = image.naturalWidth / image.naturalHeight;
     const containerAspectRatio = containerRect.width / containerRect.height;
-
     let displayWidth, displayHeight, offsetX, offsetY;
 
     if (imageAspectRatio > containerAspectRatio) {
@@ -50,14 +61,21 @@ const Map: React.FC = () => {
     }
 
     const updatedMarkers = markers.map(marker => {
-      const markerX = parseFloat(marker.left) / 100 * displayWidth - offsetX;
-      const markerY = parseFloat(marker.top) / 100 * displayHeight - offsetY;
+      const markerX = (parseFloat(marker.left) / 100) * displayWidth - offsetX;
+      const markerY = (parseFloat(marker.top) / 100) * displayHeight - offsetY;
       return { ...marker, x: markerX, y: markerY };
     });
 
     setMarkers(updatedMarkers);
-  };
+  }, [markers]);
 
+  // Initial positioning when component mounts
+  useEffect(() => {
+    positionMarkers();
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+  
+  // Update positioning when window resizes
   useEffect(() => {
     const handleResize = () => {
       positionMarkers();
@@ -65,37 +83,28 @@ const Map: React.FC = () => {
 
     window.addEventListener('resize', handleResize);
 
-    // Initial positioning
-    handleResize();
-
-    // Cleanup event listener on component unmount
     return () => {
       window.removeEventListener('resize', handleResize);
     };
-  }, [markers]);
+  }, [positionMarkers]);
+
 
   return (
     <div className="relative w-4/5 h-full overflow-hidden" ref={containerRef}>
-      <img
-        src="/images/map.svg"
-        alt="Map"
-        className="absolute object-cover h-[100%] w-[100%]"
-        ref={imageRef}
-      />
-
+      <Image
+          src="/images/map.svg"
+          alt="Map"
+          layout="fill"
+          objectFit="cover"
+          ref={imageRef}
+          onLoadingComplete={positionMarkers}
+          priority={true}
+        />
       {markers.map(marker => (
-        <a
-          key={marker.id}
-          href={marker.link}
-          className="absolute flex items-center justify-center text-white font-bold rounded-xl bg-[#ec9bfc] border-[5px] border-[#e466fc] transform -translate-x-1/2 -translate-y-1/2 w-10 h-10"
-          style={{ left: `${marker.x}px`, top: `${marker.y}px` }}
-        >
-          {marker.id}
-        </a>
+        <MemorizedMarker key={marker.id} marker={marker} />
       ))}
     </div>
   );
 };
-
 
 export default Map;


### PR DESCRIPTION
Found out that the reason for #16 is due to the fact that the map component keeps keeps recalculating the positions of markers based on the window size. This recalculation in invoked continually causing a memory leak.

To fix this, we use several optimization including memoizing the marker component, using `useCallback` to wrap the function that calculates the location of the markers and fixes the `useEffect` that invokes the function.

In addition, replacing `<img />` with `Next/Image` for further lower level optimizations